### PR TITLE
Adding the verbosity option to the arg parser of tsroot

### DIFF
--- a/src-programs/tsroot.cpp
+++ b/src-programs/tsroot.cpp
@@ -818,6 +818,7 @@ void checkOptions(Options& opts, int argc, char* argv[]) {
    appendQ  = opts.getBoolean("append");
    prependQ = opts.getBoolean("prepend");
    harmonyQ = opts.getBoolean("roman");
+   verboseQ = opts.getBoolean("verbose");
    if (prependQ) {
       appendQ = 0;
    }


### PR DESCRIPTION
I still don't know why I am getting garbage in the **tmpdir** variable at line 172 and beyond:
`cout << "\t" << tmpdir << "/" << buffer << "." << randval << endl;`
but I am guessing it is some broken pointer, similar to this: http://stackoverflow.com/questions/33234693/strange-stdcout-behaviour-with-const-char/33234729