### PR TITLE
Correcting default tempo in tsroot to match melisma output

### DIFF
--- a/src-programs/tsroot.cpp
+++ b/src-programs/tsroot.cpp
@@ -88,7 +88,10 @@ void      printRomanKey      (HumdrumFile& romananalysis,
                               vector<int>& romanlines, int target, 
                               HumdrumRecord& aRecord);
 
-double    dtempo = 120.0;
+/////////////////////////////////////////////////////////////////
+// Setting the default tempo to the same one used by kern2melisma
+//
+double    dtempo = 60.0;
 
 // global variables
 Options   options;            // database for command-line arguments


### PR DESCRIPTION
kern2melisma uses 60.0 as default tempo, since this output is fueling the meter, harmony and key programs, once it goes back to tsroot, it is expected to have those same elapsed miliseconds per event, but tsroot is using a tempo of 120.0, which is off-syncing the chord labels to the lines they should appear in.